### PR TITLE
Remove method to randomly assign princess location from grid class

### DIFF
--- a/save_princess_2/lib/grid.rb
+++ b/save_princess_2/lib/grid.rb
@@ -23,16 +23,4 @@ class Grid
     end
     coordinates
   end   
-
-  # def place_princess(size, bot)
-  #    princess = []
-  #   2.times do 
-  #     princess << rand(0..(size - 1))  
-  #   end 
-  #   if princess != bot 
-  #     @princess = princess 
-  #   else 
-  #     place_princess(size, bot)
-  #   end 
-  # end
 end


### PR DESCRIPTION
Description of Changes:
This PR removes the commented out method that randomly assigns the princess coordinates on the grid. 
Put an 'X' next to all that apply
New Test: [] New Feature:[] Bug Fix: []

Before You Submit Ensure
All Tests Pass: [] Full Coverage: [] Runs Locally: []